### PR TITLE
Add all button to lessons pages

### DIFF
--- a/themes/ananke/layouts/_default/list.html
+++ b/themes/ananke/layouts/_default/list.html
@@ -13,6 +13,7 @@
             {{ $name | title }}
           </a>
         {{ end }}
+        <a class="f5 link dim br3 ba bw1 ph3 pv2 ma2 dib dark-blue" href="{{ "/lessons/" | relURL }}">All</a>
       </nav>
     </div>
 

--- a/themes/ananke/layouts/_default/taxonomy.html
+++ b/themes/ananke/layouts/_default/taxonomy.html
@@ -14,6 +14,7 @@
             {{ $name | title }}
           </a>
         {{ end }}
+        <a class="f5 link dim br3 ba bw1 ph3 pv2 ma2 dib dark-blue" href="{{ "/lessons/" | relURL }}">All</a>
       </nav>
     </div>
 


### PR DESCRIPTION
This PR makes the following changes:

- edit ```themes/ananke/layouts/_default/list.html``` to display All button on the lessons landing page (returns user to the first page of all lessons)
- edit ```themes/ananke/layouts/_default/taxonomy.html``` to display All button on filtered pages (returns user to the first page of all lessons)

Future work should consider merging these two templates and adding highlights to the currently selected button.